### PR TITLE
add big and little endian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Due to inability to capture current file path in the stable Rust, this macro onl
 
 # Supported types:
 
-- Primitive fixed sized unsigned integers;
+- Primitive fixed sized unsigned integers with optional endianness suffix;
 
 - Arrays with unsigned integers;
 
@@ -25,6 +25,7 @@ let bytes_u16 = include_bytes!("tests/include.in" as u16);
 let bytes_u16_2 = include_bytes!("tests/include with whitespaces.in" as u16);
 let bytes_u16_3 = include_bytes!("tests/include with whitespaces.in" as [u8; 48]);
 let bytes_u16_4 = include_bytes!("tests/include with whitespaces.in" as [u16; 12]);
+let bytes_u16be = include_bytes!("tests/include.in" as u16be);
 
 assert_eq!(bytes.len(), bytes_u16.len() * 2);
 assert_eq!(bytes.len(), bytes_u16.len() * 2);
@@ -34,6 +35,7 @@ assert_eq!(bytes_u16_3[0].len(), 48);
 assert_eq!(bytes_u16_4.len(), 2);
 assert_eq!(bytes_u16_4[0].len(), 12);
 assert_eq!(bytes_u16_4[1].len(), 12);
+assert_eq!(bytes_u16be.len(), bytes_u16.len());
 ```
 
 # Debugging timings:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ impl<'a> Input<'a> {
 ///
 ///To reinterpret it as different type add `as <type>` where type can be: `u8`, `u16`, `u32`, `u64` or `u128`.
 ///
-///Change the endianness of the type by adding `le` or `be` suffix, e.g. `u16le` or `u32be`.
+///Change the endianness of how the file is interpreted by adding `le` or `be` suffix, e.g. `u16le` or `u32be`.
 ///The default endianness is native.
 ///
 ///# NOTE:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl Primitive {
     ///returns number of bytes written.
     fn write_bytes<O: fmt::Write>(&self, out: &mut O, bytes: &[u8]) -> usize {
         match self {
-            Primitive::U8 => {
+            Primitive::U8 | Primitive::U8LE | Primitive::U8BE => {
                 for byte in bytes {
                     core::fmt::write(out, format_args!("0x{:x}u8, ", byte)).expect("To write string");
                 }
@@ -198,15 +198,6 @@ impl Primitive {
                 }
                 written
             },
-            Primitive::U8LE => {
-                let mut written = 0;
-                for chunk in bytes.chunks_exact(1) {
-                    written += chunk.len();
-                    let byte = u8::from_le_bytes([chunk[0]]);
-                    core::fmt::write(out, format_args!("0x{:x}u8, ", byte)).expect("To write string");
-                }
-                written
-            },
             Primitive::U16LE => {
                 let mut written = 0;
                 for chunk in bytes.chunks_exact(2) {
@@ -240,15 +231,6 @@ impl Primitive {
                     written += chunk.len();
                     let byte = u128::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7], chunk[8], chunk[9], chunk[10], chunk[11], chunk[12], chunk[13], chunk[14], chunk[15]]);
                     core::fmt::write(out, format_args!("0x{:x}u128, ", byte)).expect("To write string");
-                }
-                written
-            },
-            Primitive::U8BE => {
-                let mut written = 0;
-                for chunk in bytes.chunks_exact(1) {
-                    written += chunk.len();
-                    let byte = u8::from_be_bytes([chunk[0]]);
-                    core::fmt::write(out, format_args!("0x{:x}u8, ", byte)).expect("To write string");
                 }
                 written
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,9 @@ impl<'a> Input<'a> {
 ///
 ///To reinterpret it as different type add `as <type>` where type can be: `u8`, `u16`, `u32`, `u64` or `u128`.
 ///
-///Change the endianness of how the file is interpreted by adding `le` or `be` suffix, e.g. `u16le` or `u32be`.
+///You can use an endianness suffix to change the expected endianness within a file.
+///When endianness is specified the macro shall treat integers within a file correspondingly to the suffix and
+///convert it to the target's native endianness. Allowed suffixes: le and be, eg. `u16le` or `u32be`.
 ///The default endianness is native.
 ///
 ///# NOTE:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,16 @@ enum Primitive {
     U32,
     U64,
     U128,
+    U8LE,
+    U16LE,
+    U32LE,
+    U64LE,
+    U128LE,
+    U8BE,
+    U16BE,
+    U32BE,
+    U64BE,
+    U128BE,
 }
 
 impl Primitive {
@@ -33,6 +43,16 @@ impl Primitive {
             Primitive::U32 => mem::size_of::<u32>(),
             Primitive::U64 => mem::size_of::<u64>(),
             Primitive::U128 => mem::size_of::<u128>(),
+            Primitive::U8LE => mem::size_of::<u8>(),
+            Primitive::U16LE => mem::size_of::<u16>(),  
+            Primitive::U32LE => mem::size_of::<u32>(),
+            Primitive::U64LE => mem::size_of::<u64>(),
+            Primitive::U128LE => mem::size_of::<u128>(),
+            Primitive::U8BE => mem::size_of::<u8>(),
+            Primitive::U16BE => mem::size_of::<u16>(),
+            Primitive::U32BE => mem::size_of::<u32>(),
+            Primitive::U64BE => mem::size_of::<u64>(),
+            Primitive::U128BE => mem::size_of::<u128>(),
         }
     }
 }
@@ -52,6 +72,16 @@ impl Type {
             "u32" => Ok(Type::Primitive(Primitive::U32)),
             "u64" => Ok(Type::Primitive(Primitive::U64)),
             "u128" => Ok(Type::Primitive(Primitive::U128)),
+            "u8le" => Ok(Type::Primitive(Primitive::U8LE)),
+            "u16le" => Ok(Type::Primitive(Primitive::U16LE)),
+            "u32le" => Ok(Type::Primitive(Primitive::U32LE)),
+            "u64le" => Ok(Type::Primitive(Primitive::U64LE)),
+            "u128le" => Ok(Type::Primitive(Primitive::U128LE)),
+            "u8be" => Ok(Type::Primitive(Primitive::U8BE)),
+            "u16be" => Ok(Type::Primitive(Primitive::U16BE)),
+            "u32be" => Ok(Type::Primitive(Primitive::U32BE)),
+            "u64be" => Ok(Type::Primitive(Primitive::U64BE)),
+            "u128be" => Ok(Type::Primitive(Primitive::U128BE)),
             other => {
                 if let Some(arg) = input.strip_prefix('[') {
                     if let Some(arg) = arg.strip_suffix(']') {
@@ -71,6 +101,16 @@ impl Type {
                             "u32" => Primitive::U32,
                             "u64" => Primitive::U64,
                             "u128" => Primitive::U128,
+                            "u8le" => Primitive::U8LE,
+                            "u16le" => Primitive::U16LE,
+                            "u32le" => Primitive::U32LE,
+                            "u64le" => Primitive::U64LE,
+                            "u128le" => Primitive::U128LE,
+                            "u8be" => Primitive::U8BE,
+                            "u16be" => Primitive::U16BE,
+                            "u32be" => Primitive::U32BE,
+                            "u64be" => Primitive::U64BE,
+                            "u128be" => Primitive::U128BE,
                             invalid => return Err(compile_error(format_args!("'as' array expression '{}' has invalid type '{}'", other, invalid))),
                         };
                         match arr_size.parse() {
@@ -158,6 +198,96 @@ impl Primitive {
                 }
                 written
             },
+            Primitive::U8LE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(1) {
+                    written += chunk.len();
+                    let byte = u8::from_le_bytes([chunk[0]]);
+                    core::fmt::write(out, format_args!("0x{:x}u8, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U16LE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(2) {
+                    written += chunk.len();
+                    let byte = u16::from_le_bytes([chunk[0], chunk[1]]);
+                    core::fmt::write(out, format_args!("0x{:x}u16, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U32LE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(4) {
+                    written += chunk.len();
+                    let byte = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                    core::fmt::write(out, format_args!("0x{:x}u32, ", byte)).expect("To write string");
+                }
+                written
+            }
+            Primitive::U64LE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(8) {
+                    written += chunk.len();
+                    let byte = u64::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7]]);
+                    core::fmt::write(out, format_args!("0x{:x}u64, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U128LE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(16) {
+                    written += chunk.len();
+                    let byte = u128::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7], chunk[8], chunk[9], chunk[10], chunk[11], chunk[12], chunk[13], chunk[14], chunk[15]]);
+                    core::fmt::write(out, format_args!("0x{:x}u128, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U8BE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(1) {
+                    written += chunk.len();
+                    let byte = u8::from_be_bytes([chunk[0]]);
+                    core::fmt::write(out, format_args!("0x{:x}u8, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U16BE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(2) {
+                    written += chunk.len();
+                    let byte = u16::from_be_bytes([chunk[0], chunk[1]]);
+                    core::fmt::write(out, format_args!("0x{:x}u16, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U32BE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(4) {
+                    written += chunk.len();
+                    let byte = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                    core::fmt::write(out, format_args!("0x{:x}u32, ", byte)).expect("To write string");
+                }
+                written
+            }
+            Primitive::U64BE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(8) {
+                    written += chunk.len();
+                    let byte = u64::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7]]);
+                    core::fmt::write(out, format_args!("0x{:x}u64, ", byte)).expect("To write string");
+                }
+                written
+            },
+            Primitive::U128BE => {
+                let mut written = 0;
+                for chunk in bytes.chunks_exact(16) {
+                    written += chunk.len();
+                    let byte = u128::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7], chunk[8], chunk[9], chunk[10], chunk[11], chunk[12], chunk[13], chunk[14], chunk[15]]);
+                    core::fmt::write(out, format_args!("0x{:x}u128, ", byte)).expect("To write string");
+                }
+                written
+            },
         }
     }
 }
@@ -170,6 +300,16 @@ impl fmt::Display for Primitive {
             Primitive::U32 => fmt.write_str("u32"),
             Primitive::U64 => fmt.write_str("u64"),
             Primitive::U128 => fmt.write_str("u128"),
+            Primitive::U8LE => fmt.write_str("u8le"),
+            Primitive::U16LE => fmt.write_str("u16le"),
+            Primitive::U32LE => fmt.write_str("u32le"),
+            Primitive::U64LE => fmt.write_str("u64le"),
+            Primitive::U128LE => fmt.write_str("u128le"),
+            Primitive::U8BE => fmt.write_str("u8be"),
+            Primitive::U16BE => fmt.write_str("u16be"),
+            Primitive::U32BE => fmt.write_str("u32be"),
+            Primitive::U64BE => fmt.write_str("u64be"),
+            Primitive::U128BE => fmt.write_str("u128be"),
         }
     }
 }
@@ -233,6 +373,9 @@ impl<'a> Input<'a> {
 ///
 ///To reinterpret it as different type add `as <type>` where type can be: `u8`, `u16`, `u32`, `u64` or `u128`.
 ///
+///Change the endianness of the type by adding `le` or `be` suffix, e.g. `u16le` or `u32be`.
+///The default endianness is native.
+///
 ///# NOTE:
 ///
 ///Due to `Span::source_file` being unstable, the file is searched relative to crate root.
@@ -253,6 +396,7 @@ impl<'a> Input<'a> {
 ///let bytes_u16_2 = include_bytes!("tests/include with whitespaces.in" as u16);
 ///let bytes_u16_3 = include_bytes!("tests/include with whitespaces.in" as [u8; 48]);
 ///let bytes_u16_4 = include_bytes!("tests/include with whitespaces.in" as [u16; 12]);
+///let bytes_u16be = include_bytes!("tests/include.in" as u16be);
 ///
 ///assert_eq!(bytes.len(), bytes_u16.len() * 2);
 ///assert_eq!(bytes.len(), bytes_u16_2.len() * 2);
@@ -261,6 +405,7 @@ impl<'a> Input<'a> {
 ///assert_eq!(bytes_u16_4.len(), 2);
 ///assert_eq!(bytes_u16_4[0].len(), 12);
 ///assert_eq!(bytes_u16_4[1].len(), 12);
+///assert_eq!(bytes_u16be.len(), bytes_u16.len());
 ///```
 ///
 ///# Debugging timings:

--- a/tests/include.rs
+++ b/tests/include.rs
@@ -12,10 +12,50 @@ fn should_include_u8_bytes() {
 }
 
 #[test]
+fn should_include_u8le_bytes() {
+    let included = include_bytes!("tests/include.in" as u8le);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u8, expected.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u8be_bytes() {
+    let included = include_bytes!("tests/include.in" as u8be);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u8, expected.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_array_u8_single() {
     let included = include_bytes!("tests/include.in" as [u8; 48]);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u8; 48], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u8le_single() {
+    let included = include_bytes!("tests/include.in" as [u8le; 48]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u8; 48], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u8be_single() {
+    let included = include_bytes!("tests/include.in" as [u8be; 48]);
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const [u8; 48], included.len())
     };
@@ -34,10 +74,54 @@ fn should_include_array_u8_multiple() {
 }
 
 #[test]
+fn should_include_array_u8le_multiple() {
+    let included = include_bytes!("tests/include.in" as [u8le; 8]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u8; 8], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u8be_multiple() {
+    let included = include_bytes!("tests/include.in" as [u8be; 8]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u8; 8], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_u16() {
     let included = include_bytes!("tests/include.in" as u16);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u16, expected.len() / 2)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u16le() {
+    let included = include_bytes!("tests/include.in" as u16le);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u16, expected.len() / 2)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u16be() {
+    let included = include_bytes!("tests/include.in" as u16be);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 2 {
+        expected.swap(i * 2, i * 2 + 1);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const u16, expected.len() / 2)
     };
@@ -56,10 +140,58 @@ fn should_include_array_u16_single() {
 }
 
 #[test]
+fn should_include_array_u16le_single() {
+    let included = include_bytes!("tests/include.in" as [u16le; 24]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u16; 24], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u16be_single() {
+    let included = include_bytes!("tests/include.in" as [u16be; 24]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 2 {
+        expected.swap(i * 2, i * 2 + 1);
+    }
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u16; 24], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_array_u16_multiple() {
     let included = include_bytes!("tests/include.in" as [u16; 12]);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u16; 12], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u16le_multiple() {
+    let included = include_bytes!("tests/include.in" as [u16le; 12]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u16; 12], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u16be_multiple() {
+    let included = include_bytes!("tests/include.in" as [u16be; 12]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 2 {
+        expected.swap(i * 2, i * 2 + 1);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const [u16; 12], included.len())
     };
@@ -78,10 +210,60 @@ fn should_include_u32() {
 }
 
 #[test]
+fn should_include_u32le() {
+    let included = include_bytes!("tests/include.in" as u32le);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u32, expected.len() / 4)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u32be() {
+    let included = include_bytes!("tests/include.in" as u32be);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 4 {
+        expected.swap(i * 4, i * 4 + 3);
+        expected.swap(i * 4 + 1, i * 4 + 2);
+    }
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u32, expected.len() / 4)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_array_u32_single() {
     let included = include_bytes!("tests/include.in" as [u32; 12]);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u32; 12], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u32le_single() {
+    let included = include_bytes!("tests/include.in" as [u32le; 12]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u32; 12], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u32be_single() {
+    let included = include_bytes!("tests/include.in" as [u32be; 12]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 4 {
+        expected.swap(i * 4, i * 4 + 3);
+        expected.swap(i * 4 + 1, i * 4 + 2);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const [u32; 12], included.len())
     };
@@ -100,10 +282,62 @@ fn should_include_array_u32_multiple() {
 }
 
 #[test]
+fn should_include_array_u32le_multiple() {
+    let included = include_bytes!("tests/include.in" as [u32le; 6]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u32; 6], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u32be_multiple() {
+    let included = include_bytes!("tests/include.in" as [u32be; 6]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 4 {
+        expected.swap(i * 4, i * 4 + 3);
+        expected.swap(i * 4 + 1, i * 4 + 2);
+    }
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u32; 6], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_u64() {
     let included = include_bytes!("tests/include.in" as u64);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u64, expected.len() / 8)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u64le() {
+    let included = include_bytes!("tests/include.in" as u64le);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u64, expected.len() / 8)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u64be() {
+    let included = include_bytes!("tests/include.in" as u64be);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 8 {
+        expected.swap(i * 8, i * 8 + 7);
+        expected.swap(i * 8 + 1, i * 8 + 6);
+        expected.swap(i * 8 + 2, i * 8 + 5);
+        expected.swap(i * 8 + 3, i * 8 + 4);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const u64, expected.len() / 8)
     };
@@ -122,10 +356,64 @@ fn should_include_array_u64_single() {
 }
 
 #[test]
+fn should_include_array_u64le_single() {
+    let included = include_bytes!("tests/include.in" as [u64le; 6]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u64; 6], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u64be_single() {
+    let included = include_bytes!("tests/include.in" as [u64be; 6]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 8 {
+        expected.swap(i * 8, i * 8 + 7);
+        expected.swap(i * 8 + 1, i * 8 + 6);
+        expected.swap(i * 8 + 2, i * 8 + 5);
+        expected.swap(i * 8 + 3, i * 8 + 4);
+    }
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u64; 6], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_array_u64_multiple() {
     let included = include_bytes!("tests/include.in" as [u64; 3]);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u64; 3], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u64le_multiple() {
+    let included = include_bytes!("tests/include.in" as [u64le; 3]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u64; 3], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u64be_multiple() {
+    let included = include_bytes!("tests/include.in" as [u64be; 3]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 8 {
+        expected.swap(i * 8, i * 8 + 7);
+        expected.swap(i * 8 + 1, i * 8 + 6);
+        expected.swap(i * 8 + 2, i * 8 + 5);
+        expected.swap(i * 8 + 3, i * 8 + 4);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const [u64; 3], included.len())
     };
@@ -144,10 +432,72 @@ fn should_include_u128() {
 }
 
 #[test]
+fn should_include_u128le() {
+    let included = include_bytes!("tests/include.in" as u128le);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u128, expected.len() / 16)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_u128be() {
+    let included = include_bytes!("tests/include.in" as u128be);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 16 {
+        expected.swap(i * 16, i * 16 + 15);
+        expected.swap(i * 16 + 1, i * 16 + 14);
+        expected.swap(i * 16 + 2, i * 16 + 13);
+        expected.swap(i * 16 + 3, i * 16 + 12);
+        expected.swap(i * 16 + 4, i * 16 + 11);
+        expected.swap(i * 16 + 5, i * 16 + 10);
+        expected.swap(i * 16 + 6, i * 16 + 9);
+        expected.swap(i * 16 + 7, i * 16 + 8);
+    }
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const u128, expected.len() / 16)
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
 fn should_include_array_u128_single() {
     let included = include_bytes!("tests/include.in" as [u128; 3]);
     let expected = read("tests/include.in").expect("To read source code");
     assert_eq!(mem::size_of_val(&included), expected.len());
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u128; 3], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u128le_single() {
+    let included = include_bytes!("tests/include.in" as [u128le; 3]);
+    let expected = read("tests/include.in").expect("To read source code");
+    let expected = unsafe {
+        slice::from_raw_parts(expected.as_ptr() as *const [u128; 3], included.len())
+    };
+    assert!(included == expected, "included doesn't match expected file output");
+}
+
+#[test]
+fn should_include_array_u128be_single() {
+    let included = include_bytes!("tests/include.in" as [u128be; 3]);
+    let mut expected = read("tests/include.in").expect("To read source code");
+    // swap bytes
+    for i in 0..expected.len() / 16 {
+        expected.swap(i * 16, i * 16 + 15);
+        expected.swap(i * 16 + 1, i * 16 + 14);
+        expected.swap(i * 16 + 2, i * 16 + 13);
+        expected.swap(i * 16 + 3, i * 16 + 12);
+        expected.swap(i * 16 + 4, i * 16 + 11);
+        expected.swap(i * 16 + 5, i * 16 + 10);
+        expected.swap(i * 16 + 6, i * 16 + 9);
+        expected.swap(i * 16 + 7, i * 16 + 8);
+    }
     let expected = unsafe {
         slice::from_raw_parts(expected.as_ptr() as *const [u128; 3], included.len())
     };

--- a/tests/include.rs
+++ b/tests/include.rs
@@ -117,14 +117,13 @@ fn should_include_u16le() {
 #[test]
 fn should_include_u16be() {
     let included = include_bytes!("tests/include.in" as u16be);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 2 {
-        expected.swap(i * 2, i * 2 + 1);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const u16, expected.len() / 2)
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut u16, expected.len() / 2)
     };
+    for integer in expected.iter_mut() {
+        *integer = integer.swap_bytes();
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -152,14 +151,15 @@ fn should_include_array_u16le_single() {
 #[test]
 fn should_include_array_u16be_single() {
     let included = include_bytes!("tests/include.in" as [u16be; 24]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 2 {
-        expected.swap(i * 2, i * 2 + 1);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u16; 24], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u16; 24], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -187,14 +187,15 @@ fn should_include_array_u16le_multiple() {
 #[test]
 fn should_include_array_u16be_multiple() {
     let included = include_bytes!("tests/include.in" as [u16be; 12]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 2 {
-        expected.swap(i * 2, i * 2 + 1);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u16; 12], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u16; 12], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -222,15 +223,13 @@ fn should_include_u32le() {
 #[test]
 fn should_include_u32be() {
     let included = include_bytes!("tests/include.in" as u32be);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 4 {
-        expected.swap(i * 4, i * 4 + 3);
-        expected.swap(i * 4 + 1, i * 4 + 2);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const u32, expected.len() / 4)
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut u32, expected.len() / 4)
     };
+    for integer in expected.iter_mut() {
+        *integer = integer.swap_bytes();
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -258,15 +257,15 @@ fn should_include_array_u32le_single() {
 #[test]
 fn should_include_array_u32be_single() {
     let included = include_bytes!("tests/include.in" as [u32be; 12]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 4 {
-        expected.swap(i * 4, i * 4 + 3);
-        expected.swap(i * 4 + 1, i * 4 + 2);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u32; 12], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u32; 12], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -294,15 +293,15 @@ fn should_include_array_u32le_multiple() {
 #[test]
 fn should_include_array_u32be_multiple() {
     let included = include_bytes!("tests/include.in" as [u32be; 6]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 4 {
-        expected.swap(i * 4, i * 4 + 3);
-        expected.swap(i * 4 + 1, i * 4 + 2);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u32; 6], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u32; 6], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -330,17 +329,13 @@ fn should_include_u64le() {
 #[test]
 fn should_include_u64be() {
     let included = include_bytes!("tests/include.in" as u64be);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 8 {
-        expected.swap(i * 8, i * 8 + 7);
-        expected.swap(i * 8 + 1, i * 8 + 6);
-        expected.swap(i * 8 + 2, i * 8 + 5);
-        expected.swap(i * 8 + 3, i * 8 + 4);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const u64, expected.len() / 8)
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut u64, expected.len() / 8)
     };
+    for integer in expected.iter_mut() {
+        *integer = integer.swap_bytes();
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -368,17 +363,15 @@ fn should_include_array_u64le_single() {
 #[test]
 fn should_include_array_u64be_single() {
     let included = include_bytes!("tests/include.in" as [u64be; 6]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 8 {
-        expected.swap(i * 8, i * 8 + 7);
-        expected.swap(i * 8 + 1, i * 8 + 6);
-        expected.swap(i * 8 + 2, i * 8 + 5);
-        expected.swap(i * 8 + 3, i * 8 + 4);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u64; 6], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u64; 6], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -406,17 +399,15 @@ fn should_include_array_u64le_multiple() {
 #[test]
 fn should_include_array_u64be_multiple() {
     let included = include_bytes!("tests/include.in" as [u64be; 3]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 8 {
-        expected.swap(i * 8, i * 8 + 7);
-        expected.swap(i * 8 + 1, i * 8 + 6);
-        expected.swap(i * 8 + 2, i * 8 + 5);
-        expected.swap(i * 8 + 3, i * 8 + 4);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u64; 3], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u64; 3], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -444,21 +435,13 @@ fn should_include_u128le() {
 #[test]
 fn should_include_u128be() {
     let included = include_bytes!("tests/include.in" as u128be);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 16 {
-        expected.swap(i * 16, i * 16 + 15);
-        expected.swap(i * 16 + 1, i * 16 + 14);
-        expected.swap(i * 16 + 2, i * 16 + 13);
-        expected.swap(i * 16 + 3, i * 16 + 12);
-        expected.swap(i * 16 + 4, i * 16 + 11);
-        expected.swap(i * 16 + 5, i * 16 + 10);
-        expected.swap(i * 16 + 6, i * 16 + 9);
-        expected.swap(i * 16 + 7, i * 16 + 8);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const u128, expected.len() / 16)
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut u128, expected.len() / 16)
     };
+    for integer in expected.iter_mut() {
+        *integer = integer.swap_bytes();
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }
 
@@ -486,20 +469,14 @@ fn should_include_array_u128le_single() {
 #[test]
 fn should_include_array_u128be_single() {
     let included = include_bytes!("tests/include.in" as [u128be; 3]);
-    let mut expected = read("tests/include.in").expect("To read source code");
-    // swap bytes
-    for i in 0..expected.len() / 16 {
-        expected.swap(i * 16, i * 16 + 15);
-        expected.swap(i * 16 + 1, i * 16 + 14);
-        expected.swap(i * 16 + 2, i * 16 + 13);
-        expected.swap(i * 16 + 3, i * 16 + 12);
-        expected.swap(i * 16 + 4, i * 16 + 11);
-        expected.swap(i * 16 + 5, i * 16 + 10);
-        expected.swap(i * 16 + 6, i * 16 + 9);
-        expected.swap(i * 16 + 7, i * 16 + 8);
-    }
+    let expected = read("tests/include.in").expect("To read source code");
     let expected = unsafe {
-        slice::from_raw_parts(expected.as_ptr() as *const [u128; 3], included.len())
+        slice::from_raw_parts_mut(expected.as_ptr() as *mut [u128; 3], included.len())
     };
+    for array in expected.iter_mut() {
+        for integer in array.iter_mut() {
+            *integer = integer.swap_bytes();
+        }
+    }
     assert!(included == expected, "included doesn't match expected file output");
 }

--- a/tests/include.rs
+++ b/tests/include.rs
@@ -121,6 +121,7 @@ fn should_include_u16be() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut u16, expected.len() / 2)
     };
+    #[cfg(target_endian = "little")]
     for integer in expected.iter_mut() {
         *integer = integer.swap_bytes();
     }
@@ -148,6 +149,7 @@ fn should_include_array_u16le_single() {
     assert!(included == expected, "included doesn't match expected file output");
 }
 
+#[cfg(target_endian = "little")]
 #[test]
 fn should_include_array_u16be_single() {
     let included = include_bytes!("tests/include.in" as [u16be; 24]);
@@ -155,6 +157,7 @@ fn should_include_array_u16be_single() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u16; 24], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -191,6 +194,7 @@ fn should_include_array_u16be_multiple() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u16; 12], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -227,6 +231,7 @@ fn should_include_u32be() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut u32, expected.len() / 4)
     };
+    #[cfg(target_endian = "little")]
     for integer in expected.iter_mut() {
         *integer = integer.swap_bytes();
     }
@@ -261,6 +266,7 @@ fn should_include_array_u32be_single() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u32; 12], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -297,6 +303,7 @@ fn should_include_array_u32be_multiple() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u32; 6], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -333,6 +340,7 @@ fn should_include_u64be() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut u64, expected.len() / 8)
     };
+    #[cfg(target_endian = "little")]
     for integer in expected.iter_mut() {
         *integer = integer.swap_bytes();
     }
@@ -367,6 +375,7 @@ fn should_include_array_u64be_single() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u64; 6], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -403,6 +412,7 @@ fn should_include_array_u64be_multiple() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u64; 3], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();
@@ -439,6 +449,7 @@ fn should_include_u128be() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut u128, expected.len() / 16)
     };
+    #[cfg(target_endian = "little")]
     for integer in expected.iter_mut() {
         *integer = integer.swap_bytes();
     }
@@ -473,6 +484,7 @@ fn should_include_array_u128be_single() {
     let expected = unsafe {
         slice::from_raw_parts_mut(expected.as_ptr() as *mut [u128; 3], included.len())
     };
+    #[cfg(target_endian = "little")]
     for array in expected.iter_mut() {
         for integer in array.iter_mut() {
             *integer = integer.swap_bytes();


### PR DESCRIPTION
For cross-platfrom portability, we need to account for the endianness of the file.

This PR adds suffixes to the data types for little and big endian. The default remains native endian.